### PR TITLE
Fixed some inconsistencies between documentation and code functionality

### DIFF
--- a/src/nodes/_nodes/OpenAIChatCompletionNode.ts
+++ b/src/nodes/_nodes/OpenAIChatCompletionNode.ts
@@ -237,7 +237,7 @@ export const OpenAIChatCompletionNode = makeNode(
 
             const apiKey = context.getApiKeyByName(apiKeyName) || "empty";
 
-            const baseUrl = ((controls.baseUrl as string) || "").trim();
+            const baseUrl = ((controls.baseUrl as string) || "https://api.openai.com").trim();
 
             const model = ((controls.model as string) || "").trim();
 

--- a/src/nodes/_nodes/OpenAITextCompletionNode.ts
+++ b/src/nodes/_nodes/OpenAITextCompletionNode.ts
@@ -150,7 +150,7 @@ export const OpenAITextCompletionNode = makeNode(
                 name: "baseUrl",
                 control: {
                     type: "text",
-                    defaultValue: "",
+                    defaultValue: "https://api.openai.com",
                     config: {
                         label: "base_url",
                     },


### PR DESCRIPTION
Documentation states that OpenAI completion nodes will default to OpenAI base URL if no base URL is supplied, however base URL defaults to an empty string.